### PR TITLE
Add product_id to get_fills request

### DIFF
--- a/crypto_export.py
+++ b/crypto_export.py
@@ -310,6 +310,7 @@ if 'gdax' in queued_exchanges:
 
     print("Creating authenticated GDAX client")
     gdax_auth_client = gdax.AuthenticatedClient(config['gdax']['key'], config['gdax']['secret'], config['gdax']['passphrase'])
+    products = gdax_auth_client.get_products()
 
     if args.local and os.path.isfile('%sgdax_accounts.json' % file_prefix):
         print("Reading GDAX account details from %sgdax_accounts.json" % file_prefix)
@@ -333,8 +334,11 @@ if 'gdax' in queued_exchanges:
         with open('%sgdax_fills.json' % file_prefix, 'r') as infile:
             gdax_fills = json.load(infile)
     else:
+        gdax_fills = []
         print("Getting GDAX order fill history via API")
-        gdax_fills = gdax_auth_client.get_fills()
+        for product in products:
+            print("Requesting fills for product", product["id"])
+            gdax_fills = gdax_fills + gdax_auth_client.get_fills(product_id=product["id"])
 
         print("Storing fill history in %sgdax_fills.json" % file_prefix)
         with open('%sgdax_fills.json' % file_prefix, 'w') as outfile:


### PR DESCRIPTION
Coinbase Pro API requires a product or order id now when requesting fills.

<img width="620" alt="Screen Shot 2019-10-29 at 11 13 15" src="https://user-images.githubusercontent.com/2758453/67758022-290a4a00-fa3d-11e9-90f3-8f17cda9498b.png">
https://docs.pro.coinbase.com/#list-fills